### PR TITLE
Add another Git reference

### DIFF
--- a/docs/ecc/git.md
+++ b/docs/ecc/git.md
@@ -10,6 +10,7 @@
 
 - 关于 Git 的使用技巧，请查看 <https://github.com/git-tips/tips>。链接内有中文版链接。
 - 关于 Git 的行为细节，请查看 <https://git-scm.com/book/en/v2>。链接内有 PDF / EPUB 下载。有中文版，但是推荐阅读英文版。
+- 关于 Git 的更多细节，请查看 <https://github.com/b1f6c1c4/learn-git-the-super-hard-way>。只有中文版。
 - 关于 Git 的具体实现，请查看 <https://github.com/git/git/tree/master/Documentation>
 - Git 源码：<https://github.com/git/git>
 


### PR DESCRIPTION
个人认为，虽然 Pro Git 是一本深入浅出、值得一看的教程，但是指望同学们在看了 Pro Git 以后直接阅读 Git 源码是不太合适的—— Pro Git 里面讲解底层命令的篇幅相比于顶层命令来说要少了许多，而 Git 实现中实际并非如此。比如 https://github.com/git/git/tree/master/builtin 里底层命令就占了一大半。所以我认为可以在 Pro Git 之后，Git 具体实现之前增加一些内容——而 [learn-git-the-super-hard-way](https://github.com/b1f6c1c4/learn-git-the-super-hard-way) 正好符合“底层命令>顶层命令”这一条件。

另外一个原因是，考虑到这个 repo 本身是在“紧急”的情况下看的， [learn-git-the-super-hard-way](https://github.com/b1f6c1c4/learn-git-the-super-hard-way) 中提供了 [完备的 cheatsheet](https://github.com/b1f6c1c4/learn-git-the-super-hard-way/blob/master/cheatsheet.md)、[数据抢修与急救](https://github.com/b1f6c1c4/learn-git-the-super-hard-way/blob/master/chapter15.md) 等实用内容，或许能够提供一些帮助。